### PR TITLE
Hotfix/readme update on method get messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ end
 Open the `lib/chat/message.ex` file and add a new function to it:
 ```elixir
 def get_messages(limit \\ 20) do
-  Chat.Repo.all(Message, limit: limit)
+  Chat.Repo.all(Chat.Message, limit: limit)
 end
 ```
 This function accepts a single parameter `limit` to only return a fixed/maximum

--- a/lib/chat/message.ex
+++ b/lib/chat/message.ex
@@ -18,6 +18,6 @@ defmodule Chat.Message do
   end
 
   def get_messages(limit \\ 10) do
-    Chat.Repo.all(Message, limit: limit)
+    Chat.Repo.all(Chat.Message, limit: limit)
   end
 end


### PR DESCRIPTION
- Updated the readme file as the instruction should be to access it via `Chat.Message`
- Updated the _lib/chat/message.ex_ file for the same issue
- issue: https://github.com/dwyl/phoenix-chat-example/issues/3