### PR TITLE
Update mix.exs to Phoenix 1.4 

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,15 +3,17 @@
 #
 # This configuration file is loaded before any dependency and
 # is restricted to this project.
-use Mix.Config
 
 # General application configuration
-config :chat, ecto_repos: [Chat.Repo]
+use Mix.Config
+
+config :chat,
+  ecto_repos: [Chat.Repo]
 
 # Configures the endpoint
 config :chat, ChatWeb.Endpoint,
   url: [host: "localhost"],
-  secret_key_base: "iH1ZNacvXr4Q9Qe7zn1s8HeDc6Dw1Oz0jKAhYGjenFqm7jAJhoXHzjbRypftyTOW",
+  secret_key_base: "B1/lHcRWBn1I9WenGINix4hEWcrI3TIk5a1SL1tRzDXqY/vSR5n9RcQYzwpcshkE",
   render_errors: [view: ChatWeb.ErrorView, accepts: ~w(html json)],
   pubsub: [name: Chat.PubSub, adapter: Phoenix.PubSub.PG2]
 
@@ -19,6 +21,9 @@ config :chat, ChatWeb.Endpoint,
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
+
+# Use Jason for JSON parsing in Phoenix
+config :phoenix, :json_library, Jason
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/chat_web/endpoint.ex
+++ b/lib/chat_web/endpoint.ex
@@ -1,66 +1,46 @@
 defmodule ChatWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :chat
 
-  socket("/socket", ChatWeb.UserSocket)
+  socket "/socket", ChatWeb.UserSocket,
+    websocket: true,
+    longpoll: false
 
   # Serve at "/" the static files from "priv/static" directory.
   #
-  # You should set gzip to true if you are running phoenix.digest
+  # You should set gzip to true if you are running phx.digest
   # when deploying your static files in production.
-  plug(
-    Plug.Static,
+  plug Plug.Static,
     at: "/",
     from: :chat,
     gzip: false,
     only: ~w(css fonts images js favicon.ico robots.txt)
-  )
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do
-    socket("/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket)
-    plug(Phoenix.LiveReloader)
-    plug(Phoenix.CodeReloader)
+    socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
+    plug Phoenix.LiveReloader
+    plug Phoenix.CodeReloader
   end
 
-  plug(Plug.RequestId)
-  plug(Plug.Logger)
+  plug Plug.RequestId
+  plug Plug.Logger
 
-  plug(
-    Plug.Parsers,
+  plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    json_decoder: Poison
-  )
+    json_decoder: Phoenix.json_library()
 
-  plug(Plug.MethodOverride)
-  plug(Plug.Head)
+  plug Plug.MethodOverride
+  plug Plug.Head
 
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.
   # Set :encryption_salt if you would also like to encrypt it.
-  plug(
-    Plug.Session,
+  plug Plug.Session,
     store: :cookie,
     key: "_chat_key",
-    signing_salt: "hn3ndJol"
-  )
+    signing_salt: "C0qf9XmQ"
 
-  plug(ChatWeb.Router)
-
-  @doc """
-  Callback invoked for dynamically configuring the endpoint.
-
-  It receives the endpoint configuration and checks if
-  configuration should be loaded from the system environment.
-  """
-  # not using :load_from_system_env for now.
-  def init(_key, config) do
-    # if config[:load_from_system_env] do
-    #   # port = System.get_env("PORT") || raise "expected the PORT environment variable to be set"
-    #   {:ok, Keyword.put(config, :http, [:inet6, port: port])}
-    # else
-    {:ok, config}
-    # end
-  end
+  plug ChatWeb.Router
 end

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule Chat.Mixfile do
       {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:gettext, "~> 0.11"},
       {:jason, "~> 1.0"},
-      {:plug_cowboy, "~> 2.0"}
+      {:plug_cowboy, "~> 2.0"},
 
       # The rest of the dependendencies are for testing/reporting
       # tracking test coverage

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Chat.Mixfile do
   def project do
     [
       app: :chat,
-      version: "1.0.0",
-      elixir: "~> 1.6",
+      version: "1.4.0",
+      elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
@@ -40,14 +40,16 @@ defmodule Chat.Mixfile do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
-      {:phoenix, "~> 1.3.0"},
-      {:phoenix_pubsub, "~> 1.0"},
-      {:phoenix_ecto, "~> 3.2"},
-      {:postgrex, ">= 0.13.5"},
-      {:phoenix_html, "~> 2.10"},
-      {:phoenix_live_reload, "~> 1.0", only: :dev},
+      {:phoenix, "~> 1.4.0"},
+      {:phoenix_pubsub, "~> 1.1"},
+      {:phoenix_ecto, "~> 4.0"},
+      {:ecto_sql, "~> 3.0"},
+      {:postgrex, ">= 0.0.0"},
+      {:phoenix_html, "~> 2.11"},
+      {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:gettext, "~> 0.11"},
-      {:cowboy, "~> 1.0"},
+      {:jason, "~> 1.0"},
+      {:plug_cowboy, "~> 2.0"}
 
       # The rest of the dependendencies are for testing/reporting
       # tracking test coverage


### PR DESCRIPTION
@iteles just noticed that I forgot to update the version of Phoenix in the mix.exs file ... 🙄 (_derp!_)
+ [x] update version of Phoenix to v.1.4 for https://github.com/dwyl/learn-phoenix-framework/issues/118
+ [x] update config to use `Phoenix.json_library()` https://github.com/dwyl/phoenix-chat-example/pull/13#issuecomment-439274300

> note: I have it updated on my "personal walkthrough" of this example: https://github.com/nelsonic/phoenix-chat-v1.4/blob/059db8850bee14d95f0caeb12d54d7485d402503/mix.exs#L36 but forgot to do it here!

Thanks for reviewing/merging. 👍 