### PR TITLE
Remove row class from UL element

### DIFF
--- a/lib/chat_web/templates/page/index.html.eex
+++ b/lib/chat_web/templates/page/index.html.eex
@@ -1,5 +1,5 @@
 <!-- The list of messages will appear here: -->
-<ul id="msg-list" class="row" style="list-style: none; min-height:200px;
+<ul id="msg-list" style="list-style: none; min-height:200px;
   border: 1px solid #e5e5e5; margin: 10px; padding: 10px;">
   <%= for m <- @messages do %>
     <li id="<%= m.id %>"><b> <%= m.name %> </b> <%= m.message %> </li>


### PR DESCRIPTION
Remove row class from UL element so chat messages are displayed vertically instead of inline.