### PR TITLE
Add presence support

### DIFF
--- a/lib/chat/application.ex
+++ b/lib/chat/application.ex
@@ -11,9 +11,10 @@ defmodule Chat.Application do
       # Start the Ecto repository
       supervisor(Chat.Repo, []),
       # Start the endpoint when the application starts
-      supervisor(ChatWeb.Endpoint, [])
+      supervisor(ChatWeb.Endpoint, []),
       # Start your own worker by calling: Chat.Worker.start_link(arg1, arg2, arg3)
       # worker(Chat.Worker, [arg1, arg2, arg3]),
+      Chat.Presence
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/chat/presence.ex
+++ b/lib/chat/presence.ex
@@ -1,0 +1,5 @@
+defmodule Chat.Presence do
+  use Phoenix.Presence,
+    otp_app: :chat,
+    pubsub_server: Chat.PubSub
+end

--- a/lib/chat_web/templates/page/index.html.eex
+++ b/lib/chat_web/templates/page/index.html.eex
@@ -1,8 +1,16 @@
+<div class="row">
+  <div class="col-xs-12 col-sm-3">
+    <ul id="online-users" style="list-style: none; min-height:200px;
+    border: 1px solid #e5e5e5; padding: 10px">
+    <li class="text-left"><b><u>Online users</u></b></li>
+  </ul>
+</div>
 <!-- The list of messages will appear here: -->
-<ul id="msg-list" style="list-style: none; min-height:200px;
-  border: 1px solid #e5e5e5; margin: 10px; padding: 10px;">
+<div class="col-xs-12 col-sm-9">
+  <ul id="msg-list" style="list-style: none; min-height:200px;
+  border: 1px solid #e5e5e5; padding: 10px">
   <%= for m <- @messages do %>
-    <li id="<%= m.id %>"><b> <%= m.name %> </b> <%= m.message %> </li>
+  <li id="<%= m.id %>"><b> <%= m.name %> </b> <%= m.message %> </li>
   <% end %>
 </ul>
 
@@ -13,4 +21,6 @@
   <div class="col-xs-9">
     <input type="text" id="msg" class="form-control" placeholder="Your Message">
   </div>
+</div>
+</div>
 </div>


### PR DESCRIPTION
### There is a gotcha here:

Since there is no concept of user logins and sessions based on it, I felt its okay to mark a user as online once a message with a name is made. Presence would then track that particular user as opposed to tracking when the page loads.

Also, I've added a timestamp field to the Phoenix Presence tracker in the backend, but I chose to keep the UI simple.

Closes #14 