### PR TITLE
Fix row chat message layout in README.md code section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,14 +401,15 @@ and _copy-paste_ (_or type_) the following code:
 
 ```html
 <!-- The list of messages will appear here: -->
-<ul id='msg-list' class='row' style='list-style: none; min-height:200px; padding: 10px;'></ul>
+<ul id="msg-list" style="list-style: none; min-height:200px;">
+</ul>
 
 <div class="row">
-  <div class="column column-20">
-    <input type="text" id="name" class="form-control" placeholder="Your Name" autofocus>
+  <div class="col-xs-3" style="width: 20%; margin-left: 0;">
+    <input type="text" id="name" class="form-control" placeholder="Your Name" style="border: 1px black solid; font-size: 1.3em;" autofocus>
   </div>
-  <div class="column column-80">
-    <input type="text" id="msg" class="form-control" placeholder="Your Message">
+  <div class="col-xs-9" style="width: 100%; margin-left: 1%; ">
+    <input type="text" id="msg" class="form-control" placeholder="Your Message" style="border: 1px black solid; font-size: 1.3em;">
   </div>
 </div>
 ```


### PR DESCRIPTION
This has already been fixed in the file itself as https://github.com/dwyl/phoenix-chat-example/issues/18 but not in the readme section.
Copy pasting the suggested code create the same row layout as the issue describe. 
![image](https://user-images.githubusercontent.com/6450385/105885797-e8b3c600-6009-11eb-817d-2bfa2e7f673b.png)

This pull request change the css to be closer to the [original file](https://github.com/dwyl/phoenix-chat-example/blob/00b79e3408cf0a0c5392389f47b39081ef1c6681/lib/chat_web/templates/page/index.html.eex)
![image](https://user-images.githubusercontent.com/6450385/105885862-fec18680-6009-11eb-95e3-7cdaf253f1b3.png)

Modifications on chat inputs is are bit verbose, I can remove it to be cleaner to copy/paste.

Thanks for this tutorial :+1: 