### PR TITLE
trailing commas are not allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,9 +908,10 @@ Open your `mix.exs` file and find the "deps" function:
 defp deps do
 ```
 
-Add the following line to the end of the List:
+Add a comma to the end of the last line, then add the following line to the end
+of the List:
 ```elixir
-{:excoveralls, "~> 0.13.0", only: [:test, :dev]}, # tracking test coverage
+{:excoveralls, "~> 0.13.0", only: [:test, :dev]} # tracking test coverage
 ```
 
 Additionally, find the `def project do` section (_towards the top of `mix.exs`_)


### PR DESCRIPTION
If you follow the instructions for adding coveralls as written, you end up with an invalid list; it tells you to add coveralls to the end of the list but it has a trailing comma, which is invalid.

Alternately, perhaps the doc could suggest adding it to the beginning of the list? But I don't know if that has any side effects.