### PR TITLE
Updated the default text that comes with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,13 +601,13 @@ Open the `test/chat_web/controllers/page_controller_test.exs` file
 and replace the line:
 
 ```elixir
-assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+    assert html_response(conn, 200) =~ "Peace of mind from prototype to production"
 ```
 
 With:
 
 ```elixir
-assert html_response(conn, 200) =~ "Phoenix Chat Example"
+    assert html_response(conn, 200) =~ "Phoenix Chat Example"
 ```
 
 Now if you run the tests again, they will pass:


### PR DESCRIPTION
The default text that comes with the test is not changed to this 
- "Peace of mind from prototype to production"

some new users (like me) would find it easy to follow along


This is my page_controller_test.exs
```elixir
defmodule ChatWeb.PageControllerTest do
  use ChatWeb.ConnCase

  test "GET /", %{conn: conn} do
    conn = get(conn, ~p"/")
    assert html_response(conn, 200) =~ "Peace of mind from prototype to production"
  end
end
```