### PR TITLE
Update README.md footer class styling for home.html.heex file #257

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ and _copy-paste_ (_or type_) the following code:
   <ul id="msg-list" phx-update="append" class="pa-1"></ul>
 </div>
 
-<footer class="bg-slate-800 p-2 h-[3rem] bottom-0 w-full flex justify-center sticky mt-[auto]">
+<footer class="bg-slate-800 p-2 h-[3rem] fixed bottom-0 w-full flex justify-center">
   <div class="w-full flex flex-row items-center text-gray-700 focus:outline-none font-normal">
     <input type="text" id="name" placeholder="Name" required
         class="grow-0 w-1/6 px-1.5 py-1.5"/>


### PR DESCRIPTION
There was a mismatch in code for the readme example of the home.html.heex file, and the linked example. The embedded readme example code had styling issue with the footer being connected to the top of the page.

Changes to `/lib/chat_web/controllers/page_html/home.html.heex` example code:

Changes to the `<footer class="...">`
- Removed `sticky mt-[auto]`
- Changed `bottom-0` to `fixed bottom-0`