### PR TITLE
Update README.md deprecated event.keycode, hyperlink and windows command #259

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,8 +840,9 @@ In your terminal run the following command to create the `messages` table:
 ```sh
 mix ecto.migrate
 ```
-> For a bit of _context_  we recommend reading:
-[https://hexdocs.pm/phoenix/**testing_channels**.html](https://hexdocs.pm/ecto_sql/Ecto.Migration.html)
+
+> For _context_  we recommend reading:
+[hexdocs.pm/ecto_sql/**Ecto.Migration**.html](https://hexdocs.pm/ecto_sql/Ecto.Migration.html)
 
 You should see the following in your terminal:
 ```sh
@@ -1172,7 +1173,10 @@ into your terminal:
 ```elixir
 MIX_ENV=test mix do coveralls.json
 ```
-> For windows use: `$env:MIX_ENV="test"; mix do coveralls.json`
+> For windows use:
+> ```elixir
+> $env:MIX_ENV="test"; mix do coveralls.json
+> ```
 
 You should see: <br />
 

--- a/README.md
+++ b/README.md
@@ -699,7 +699,7 @@ function render_message(payload) {
 
 // Listen for the [Enter] keypress event to send a message:
 msg.addEventListener('keypress', function (event) {
-  if (event.keyCode == 13 && msg.value.length > 0) { // don't sent empty msg.
+  if (event.key === `Enter` && msg.value.length > 0) { // don't sent empty msg.
     sendMessage()
   }
 });
@@ -840,6 +840,9 @@ In your terminal run the following command to create the `messages` table:
 ```sh
 mix ecto.migrate
 ```
+> For a bit of _context_  we recommend reading:
+[https://hexdocs.pm/phoenix/**testing_channels**.html](https://hexdocs.pm/ecto_sql/Ecto.Migration.html)
+
 You should see the following in your terminal:
 ```sh
 11:42:10.130 [info] == Running 20230203114114 Chat.Repo.Migrations.CreateMessages.change/0 forward
@@ -1169,6 +1172,7 @@ into your terminal:
 ```elixir
 MIX_ENV=test mix do coveralls.json
 ```
+> For windows use: `$env:MIX_ENV="test"; mix do coveralls.json`
 
 You should see: <br />
 


### PR DESCRIPTION
- event.keycode deprecated
- added hyperlink for ecto.migration
- added windows terminal command for MIX_ENV